### PR TITLE
Pathname in quotes to care for spaces in pathname

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,7 +9,7 @@ export function activate(context: vscode.ExtensionContext) {
         if (!editor) {
             return;
         }
-        
+
         let document = editor.document;
         if (!document) {
             return;
@@ -23,7 +23,7 @@ export function activate(context: vscode.ExtensionContext) {
         let dir = path.dirname(uri.fsPath);
         let terminal = vscode.window.createTerminal();
         terminal.show(false);
-        terminal.sendText(`cd ${dir}`);
+        terminal.sendText(`cd "${dir}"`);
     });
 
     context.subscriptions.push(disposable);


### PR DESCRIPTION
Just enclose the pathname in double quotes to properly handle file names with embedded quotes.
