### PR TITLE
Support Windows Subsystem for Linux

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,6 +21,12 @@ export function activate(context: vscode.ExtensionContext) {
         }
 
         let dir = path.dirname(uri.fsPath);
+
+        if(isWslBash(vscode.workspace.getConfiguration('terminal'))) {
+            // c:\workspace\foo to /mnt/c/workspace/foo
+            dir = dir.replace(/(\w):/, '/mnt/$1').replace(/\\/g, '/')
+        }
+
         let terminal = vscode.window.createTerminal();
         terminal.show(false);
         terminal.sendText(`cd "${dir}"`);
@@ -30,4 +36,21 @@ export function activate(context: vscode.ExtensionContext) {
 }
 
 export function deactivate() {
+}
+
+function isWslBash(terminalSettings) {
+    const windowsShellPath = terminalSettings.integrated.shell.windows;
+
+    if(!windowsShellPath) {
+        return false;
+    }
+
+    // Detect WSL bash according to the implementation of VS Code terminal.
+    // For more details, refer to https://goo.gl/AuwULb
+    const is32ProcessOn64Windows = process.env.hasOwnProperty('PROCESSOR_ARCHITEW6432');
+    const system32 = is32ProcessOn64Windows ? 'Sysnative' : 'System32';
+    const expectedWslBashPath = path.join(process.env.windir, system32, 'bash.exe');
+
+    // %windir% can give WINDOWS instead of Windows
+    return windowsShellPath.toLowerCase() === expectedWslBashPath.toLowerCase();
 }


### PR DESCRIPTION
Fixes #5 

It determines the directory path by checking Windows shell path.
The shell paths are listed in the official VS Code page.
https://code.visualstudio.com/docs/editor/integrated-terminal

Please kindly consider this pull request to be merged, I really need this feature.

Screen captures of the actual usages:
```
"terminal.integrated.shell.windows": "C:\\Windows\\System32\\bash.exe"
```
![image](https://user-images.githubusercontent.com/7734590/34453017-d04db6a8-ed8d-11e7-93b4-70d3145f0971.png)

```
"terminal.integrated.shell.windows": "C:\\Program Files\\Git\\bin\\bash.exe"
```
![image](https://user-images.githubusercontent.com/7734590/34453019-d56dc7ae-ed8d-11e7-8359-6eef1b3c3da0.png)