### PR TITLE
Change drive letter before cd in case of cmd.exe

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,13 +22,20 @@ export function activate(context: vscode.ExtensionContext) {
 
         let dir = path.dirname(uri.fsPath);
 
-        if(isWslBash(vscode.workspace.getConfiguration('terminal'))) {
-            // c:\workspace\foo to /mnt/c/workspace/foo
-            dir = dir.replace(/(\w):/, '/mnt/$1').replace(/\\/g, '/')
-        }
-
         let terminal = vscode.window.createTerminal();
         terminal.show(false);
+
+        switch(kindOfShell(vscode.workspace.getConfiguration('terminal'))) {
+            case "wslbash":
+                // c:\workspace\foo to /mnt/c/workspace/foo
+                dir = dir.replace(/(\w):/, '/mnt/$1').replace(/\\/g, '/')
+                break;
+            case "cmd":
+                // send 1st two characters (drive letter and colon) to the terminal
+                // so that drive letter is updated before running cd
+                terminal.sendText(dir.slice(0,2));
+        }
+
         terminal.sendText(`cd "${dir}"`);
     });
 
@@ -38,19 +45,21 @@ export function activate(context: vscode.ExtensionContext) {
 export function deactivate() {
 }
 
-function isWslBash(terminalSettings) {
+function kindOfShell(terminalSettings) {
     const windowsShellPath = terminalSettings.integrated.shell.windows;
 
     if(!windowsShellPath) {
-        return false;
+        return undefined;
     }
 
     // Detect WSL bash according to the implementation of VS Code terminal.
     // For more details, refer to https://goo.gl/AuwULb
     const is32ProcessOn64Windows = process.env.hasOwnProperty('PROCESSOR_ARCHITEW6432');
     const system32 = is32ProcessOn64Windows ? 'Sysnative' : 'System32';
-    const expectedWslBashPath = path.join(process.env.windir, system32, 'bash.exe');
+    var shellKindByPath = {}
+    shellKindByPath[path.join(process.env.windir, system32, 'bash.exe').toLowerCase()] = "wslbash";
+    shellKindByPath[path.join(process.env.windir, system32, 'cmd.exe').toLowerCase()] = "cmd";
 
     // %windir% can give WINDOWS instead of Windows
-    return windowsShellPath.toLowerCase() === expectedWslBashPath.toLowerCase();
+    return shellKindByPath[windowsShellPath.toLowerCase()]
 }


### PR DESCRIPTION
Fixes #4

This checks if the windows shell is cmd.exe similar to wsl bash check in pull request #10.

I modified the "isWslBash" function and made a "kindOfShell" that returns string "wslbash" or "cmd".
This was to avoid creating a new function isCmd and duplicating most of the code from isWslBash.
So now instead of an if condition we have a switch case.

In cmd.exe cd works only for paths within the current drive letter (which is C: usually when cmd is started).
To change the drive letter we need to send the drive letter and a colon to the terminal.

Screen cap:

![capture](https://user-images.githubusercontent.com/5345275/34512128-43958ae6-f086-11e7-8d62-9538da3872cf.PNG)